### PR TITLE
Include the required appMinorVersionSupported tag for GeoNetwork vers…

### DIFF
--- a/src/main/plugin/sensorML/schema-ident.xml
+++ b/src/main/plugin/sensorML/schema-ident.xml
@@ -3,6 +3,7 @@
 	<name>sensorML</name>
 	<id>8cc7a922-dbb4-4e9a-bfea-d406b57deb04</id>
 	<version>1.0.1</version>
+	<appMinorVersionSupported>3.4.0</appMinorVersionSupported>
 	<schemaLocation>http://www.opengis.net/sensorML/1.0.1 http://www.opengis.net/sensorML/1.0.1/sensorML.xsd http://www.opengis.net/swe/1.0.1 http://www.opengis.net/swe/1.0.1/swe.xsd http://www.opengis.net/gml http://schemas.opengis.org/gml/3.1.1/base/gml.xsd http://www.w3.org/1999/xlink http://www.w3.org/1999/xlink/xlinks.xsd</schemaLocation>
 	<autodetect xmlns:sml="http://www.opengis.net/sensorML/1.0.1">
 		<elements type="root">


### PR DESCRIPTION
I needed to include this change to be able to use this sensorML schema plugin with GeoNetwork versions later than 3.4.x (notably 3.10.10 with the log4j2 version patch included)